### PR TITLE
1.1.0: Unified handler types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.0
+
+- Unified the handler types with new `IResponsibilityNode` signature and `IResponsibilityNodeBase` hint interface.
+- Added a `chain` method to replace the existing `node` and `funcNode` methods.
+- **Deprecated the `ResponsibilityNode`, `FunctionNode`, `FunctionHandler`, `ResponsibilityChain.node`,
+  and `ResponsibilityChain.funcNode` entries. These will be removed in _2.0.0_.**
+
 ## 1.0.3
 
 - Reordered the CHANGELOG.md for the latest changes to appear first.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 ## Asynchronous Responsibility Chain Pattern
 
+> **Version 1.1.0 deprecated the `node` and `funcNode` methods and respective handler classes. They will be removed in 
+> 2.0.0, and the pre-release version will be available shortly. 
+> Refer to the README and deprecation warnings for detailed changes.**
+
 This library provides an implementation of the Responsibility Chain pattern that works asynchronously and utilizes
 the functional and object-oriented approaches to creating responsibility handlers.
 

--- a/example/responsibility_chain_example.dart
+++ b/example/responsibility_chain_example.dart
@@ -40,7 +40,7 @@ ChainResult<double> localCacheHandler(int date) {
   return ChainResult.success(rate);
 }
 
-/// A object-style handler.
+/// An object-style handler.
 /// Must have a [call] function complying to the [IResponsibilityNode] signature.
 ///
 /// It is not required to implement [IResponsibilityNodeBase], but this way the analyzer will hint the types for you.

--- a/example/responsibility_chain_example.dart
+++ b/example/responsibility_chain_example.dart
@@ -1,17 +1,16 @@
 import 'package:responsibility_chain/responsibility_chain.dart';
 
-/// This example demonstrates how to use the FunctionHandlers of the `responsibility_chain` package.
-/// The usage of the ResponsibilityNode subclasses will look exactly the same, but with an
+/// This example demonstrates how to use create and use responsibility nodes from the `responsibility_chain` package.
+/// The usage of the IResponsibilityNodeBase subclasses will look exactly the same, but with an
 /// additional step of creating inherited classes for handlers.
-///
-/// I consider it a good idea to use FunctionHandlers to simplify your code when possible, though
-/// the base class can be inherited from or mixed with to implement more complex abstractions.
-///
 void main() async {
-  final rateFetchRespChain =
-      ResponsibilityChainWithArgs<double, int>(orElse: (_) => -1)
-        ..funcNode((args) => databaseFetchHandler(args))
-        ..funcNode(serverFetchHandler);
+  // create a chain instance and chain handlers to it
+  final rateFetchRespChain = ResponsibilityChainWithArgs<double, int>(
+      orElse: (_) => -1)
+    // the handlers can be functions with the [IResponsibilityNode] signature
+    ..chain(localCacheHandler)
+    // or [IResponsibilityNodeBase]-like objects for more complex logic
+    ..chain(const ServerFetchHandler());
 
   // the result handling is always happens asynchronously
   // the argument will be passed to each of the handler nodes during the execution
@@ -31,21 +30,30 @@ void main() async {
   print(await rateFetchRespChain.handle(20230209));
 }
 
-/* Mocks */
+/* Chain Nodes examples */
 
-ChainResult<double> databaseFetchHandler(int date) {
+/// A functional-style handler. Must comply to the [IResponsibilityNode] signature.
+ChainResult<double> localCacheHandler(int date) {
   final rate = localDatabaseMock[date];
 
   if (rate == null) return ChainResult.failure();
   return ChainResult.success(rate);
 }
 
-// handlers can return both ChainResult<R> and Future<ChainResult<R>>
-Future<ChainResult<double>> serverFetchHandler(int date) async {
-  final rate = exchangeRateServerMock[date];
+/// A object-style handler.
+/// Must have a [call] function complying to the [IResponsibilityNode] signature.
+///
+/// It is not required to implement [IResponsibilityNodeBase], but this way the analyzer will hint the types for you.
+class ServerFetchHandler implements IResponsibilityNodeBase<double, int> {
+  const ServerFetchHandler();
 
-  if (rate == null) return ChainResult.failure();
-  return ChainResult.success(rate);
+  @override
+  Future<ChainResult<double>> call(int date) async {
+    final rate = exchangeRateServerMock[date];
+
+    if (rate == null) return ChainResult.failure();
+    return ChainResult.success(rate);
+  }
 }
 
 const localDatabaseMock = {
@@ -62,33 +70,3 @@ const exchangeRateServerMock = {
   20230213: 13.0,
   20230212: 12.0,
 };
-
-// void main() {
-//   final chain = ResponsibilityChain<int>()
-//     ..node(() => DatabaseFetchHandler())
-//     ..node(() => ApiFetchHandler());
-//
-//   chain.handle().then(print);
-// }
-//
-//
-// // final chain = ResponsibilityChain<int, void>()
-// //   ..funcNode((_) => ChainResult.failure())
-// //   ..funcNode((_) => ChainResult.success(31122003))
-// //   ..orElse((_) => 0);
-//
-// class DatabaseFetchHandler extends ResponsibilityNode<int, void> {
-//   @override
-//   Future<ChainResult<int>> handle(void args) async => ChainResult.success(await compute());
-//
-//   Future<int> compute() {
-//     return Future.delayed(const Duration(milliseconds: 500), () {
-//       throw Exception();
-//     });
-//   }
-// }
-//
-// class ApiFetchHandler extends ResponsibilityNode<int, void> {
-//   @override
-//   Future<ChainResult<int>> handle(void args) => Future.value(ChainResult.success(14022022));
-// }

--- a/lib/responsibility_chain.dart
+++ b/lib/responsibility_chain.dart
@@ -10,10 +10,8 @@
 ///
 library responsibility_chain;
 
-import 'src/chain.dart';
-import 'src/node.dart';
-
+export 'src/abs/node.dart' show IResponsibilityNode, IResponsibilityNodeBase;
 export 'src/chain.dart' show ResponsibilityChain, ResponsibilityChainWithArgs;
 export 'src/node.dart' show ResponsibilityNode, FunctionalNode;
 export 'src/result.dart' show ChainResult;
-export 'src/typedefs.dart' show FunctionHandler, VoidFunctionHandler;
+export 'src/typedefs.dart' show FunctionHandler, VoidFunctionHandler, Supplier;

--- a/lib/src/abs/node.dart
+++ b/lib/src/abs/node.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+
+import '../../responsibility_chain.dart';
+
+/// A typedef representing a handler (responsibility node) that takes [args] of type [A] and returns a
+/// Future<[ChainResult]> or [ChainResult] itself with the type parameter of [R].
+/// Calling this method should either return a FutureOr<[ChainResult]<[R]>>, or throw an exception.
+/// Throwing an exception will have the same effect as returning a [ChainResult.failure].
+///
+/// Alternatively, if you need to use objects as nodes, implement [IResponsibilityNodeBase] and treat its objects as
+/// regular [IResponsibilityNode]s.
+///
+/// See also: [ChainResult], [IResponsibilityNodeBase].
+typedef IResponsibilityNode<R, A> = FutureOr<ChainResult<R>> Function(A args);
+
+/// An alternative way to declare responsibility node handlers - implement [IResponsibilityNode] and treat its objects
+/// as regular [IResponsibilityNode]s.
+///
+/// The only method that needs to be implemented is [call], which corresponds to a [IResponsibilityNode] function type.
+abstract class IResponsibilityNodeBase<R, A> {
+  const IResponsibilityNodeBase();
+
+  /// A method that corresponds to the [IResponsibilityNode] signature.
+  /// This method should either return a FutureOr<[ChainResult]<[R]>>, or throw an exception.
+  ///
+  /// Throwing an exception will have the same effect as returning a [ChainResult.failure].
+  FutureOr<ChainResult<R>> call(A args);
+}

--- a/lib/src/adapter/deprecated_node_adapter.dart
+++ b/lib/src/adapter/deprecated_node_adapter.dart
@@ -1,0 +1,10 @@
+import 'package:meta/meta.dart';
+
+import '../abs/node.dart';
+import '../node.dart';
+
+@protected
+IResponsibilityNode<R, A> wrapDeprecatedNode<R, A>(
+  ResponsibilityNode<R, A> node,
+) =>
+    node.handle;

--- a/lib/src/chain.dart
+++ b/lib/src/chain.dart
@@ -1,5 +1,9 @@
 import 'dart:async';
 
+import 'package:meta/meta.dart';
+
+import 'abs/node.dart';
+import 'adapter/deprecated_node_adapter.dart';
 import 'node.dart';
 import 'result.dart';
 import 'typedefs.dart';
@@ -12,20 +16,22 @@ import 'typedefs.dart';
 ///
 abstract class IResponsibilityChain<R, A> {
   /// The list of nodes that are currently chained to this responsibility chain.
-  ///
-  List<Supplier<ResponsibilityNode<R, A>>> get nodes;
+  @visibleForTesting
+  List<IResponsibilityNode<R, A>> get nodes;
 
   /// The function that returns the default value of type [R].
   ///
   /// The result of this function will be used when none of the handler nodes succeed to return the
   /// result.
-  ///
+  @visibleForTesting
   ParametrizedSupplier<R, A> get orElse;
 
   /// Chains the given node to this chain.
   ///
   /// - The [layerNode] is a function returning a [ResponsibilityNode] ancestor object.
-  ///
+  @Deprecated(
+    'ResponsibilityChain.node is replaced by ResponsibilityNode.chain and will be removed in 2.0.0',
+  )
   void node(Supplier<ResponsibilityNode<R, A>> layerNode);
 
   /// Chains the given function to this chain. The given function will be wrapped in the closure
@@ -33,11 +39,19 @@ abstract class IResponsibilityChain<R, A> {
   ///
   /// - The [functionHandler] is a [FunctionHandler]. It must either return [ChainResult]<[R]> or
   /// throw one of [Exception] subclasses.
-  ///
+  @Deprecated(
+    'ResponsibilityChain.funcNode is replaced by ResponsibilityNode.chain and will be removed in 2.0.0',
+  )
   void funcNode(FunctionHandler<R, A> functionHandler);
 
-  /// This method iterates through the chained nodes in the precise order they have been chained and
-  /// calls the [ResponsibilityNode.handle] method with the argument of [args].
+  /// Adds a given [node] to this chain.
+  ///
+  /// The given node can either be a [IResponsibilityNode] function, or an [IResponsibilityNodeBase] ancestor
+  /// class object.
+  void chain(IResponsibilityNode<R, A> node);
+
+  /// This method iterates through the chained nodes in the precise order they had been chained and
+  /// calls the [IResponsibilityNode]s with the argument [arg].
   ///
   /// If a node returns a successful result, the method stops iterating and returns the result.
   /// Otherwise, if the result is not successful or throws an exception is thrown, the method
@@ -45,41 +59,48 @@ abstract class IResponsibilityChain<R, A> {
   ///
   /// If no chained node succeeded to return a successful result, the result of [orElse] function is
   /// returned.
-  ///
-  Future<R> handle(A args);
+  Future<R> handle(A arg);
 }
 
 /// In contrast to the [ResponsibilityChain], this class allows to pass the argument of type [A] to
 /// its [handle] method. This argument will be passed to every handler node in the chain.
 ///
-/// For other functionality, see the [ResponsibilityChain] documentation.
-///
+/// For other features, see the [ResponsibilityChain] documentation.
 class ResponsibilityChainWithArgs<R, A> implements IResponsibilityChain<R, A> {
+  @visibleForTesting
+  @override
+  final List<IResponsibilityNode<R, A>> nodes = [];
+
+  @visibleForTesting
   @override
   final ParametrizedSupplier<R, A> orElse;
 
-  @override
-  final List<Supplier<ResponsibilityNode<R, A>>> nodes = [];
-
   ResponsibilityChainWithArgs({required this.orElse});
 
+  @Deprecated(
+    'ResponsibilityChain.node is replaced by ResponsibilityChain.chain and will be removed in 2.0.0',
+  )
   @override
   void node(Supplier<ResponsibilityNode<R, A>> layerNodeSupplier) =>
-      nodes.add(layerNodeSupplier);
+      nodes.add(wrapDeprecatedNode(layerNodeSupplier()));
 
+  @Deprecated(
+    'ResponsibilityNode.funcNode is replaced by ResponsibilityChain.chain and will be removed in 2.0.0',
+  )
   @override
   void funcNode(FunctionHandler<R, A> functionHandler) =>
       node(() => FunctionalNode.withArgs(functionHandler));
 
   @override
+  void chain(IResponsibilityNode<R, A> node) => nodes.add(node);
+
+  @override
   Future<R> handle(A args) async {
     ChainResult<R>? lastResult;
 
-    for (final nodeSupplier in nodes) {
-      final node = nodeSupplier.call();
-
+    for (final node in nodes) {
       try {
-        lastResult = await node.handle(args);
+        lastResult = await node(args);
       } on Exception {
         continue;
       }
@@ -101,13 +122,10 @@ class ResponsibilityChainWithArgs<R, A> implements IResponsibilityChain<R, A> {
 ///
 /// The type parameter [R] represents the type of the result returned by the chain.
 ///
-/// - The [node] method takes the function returning the node which will be chained;
-/// - The [funcNode] method takes the function returning the [ChainResult] and wraps it in a
-/// [FunctionalNode] before chaining;
+/// - The [chain] method adds a responsibility node to the end of this chain;
 /// - The [handle] method returns the Future of [R] and lets the chained handle nodes successively
 /// try to return the value. If none of the handlers succeed, the result of [orElse] will be
 /// returned.
-///
 class ResponsibilityChain<R> extends ResponsibilityChainWithArgs<R, void> {
   ResponsibilityChain({required super.orElse});
 

--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -13,13 +13,19 @@ import '../responsibility_chain.dart';
 ///
 /// The other way to implement the handler is to use [FunctionHandler]s (or utilize [FunctionalNode]
 /// objects directly).
-///
+@Deprecated(
+  'ResponsibilityNode and FunctionalNode handlers are replaced by '
+  'IResponsibilityNodeBase and IResponsibilityNode respectively and will be removed in 2.0.0',
+)
 abstract class ResponsibilityNode<R, A> {
   /// A method that is called when the node is responsible for the getting the chain result.
   ///
   /// This method should either return FutureOr<[ChainResult]<[R]>> or throw an exception.
   /// Throwing an exception will have the same effect as returning the [ChainResult.failure].
-  ///
+  @Deprecated(
+    'ResponsibilityNode and FunctionalNode handlers are replaced by '
+    'IResponsibilityNodeBase and IResponsibilityNode respectively and will be removed in 2.0.0',
+  )
   FutureOr<ChainResult<R>> handle(A args);
 
   const ResponsibilityNode();
@@ -34,22 +40,30 @@ abstract class ResponsibilityNode<R, A> {
 /// It is not necessary to create the [FunctionalNode] objects directly - the
 /// [ResponsibilityChain.funcNode] method will create them automatically from the given
 /// [FunctionHandler].
-///
+@Deprecated(
+  'ResponsibilityNode and FunctionalNode handlers are replaced by '
+  'IResponsibilityNodeBase and IResponsibilityNode respectively and will be removed in 2.0.0',
+)
 class FunctionalNode<R, A> extends ResponsibilityNode<R, A> {
   /// A [FunctionHandler] taking the argument of the type [A] and returning a [ChainResult]<[R]>.
   ///
   /// The function is also allowed to throw an exception, which have the same effect as returning
   /// the [ChainResult.failure].
-  ///
   final FunctionHandler<R, A> handler;
 
   /// Creates a [FunctionalNode] from [VoidFunctionHandler] which does not take any arguments.
-  ///
+  @Deprecated(
+    'ResponsibilityNode and FunctionalNode handlers are replaced by '
+    'IResponsibilityNodeBase and IResponsibilityNode respectively and will be removed in 2.0.0',
+  )
   FunctionalNode(VoidFunctionHandler<R> handler)
       : handler = ((args) => handler());
 
   /// Creates a [FunctionalNode] from [FunctionHandler], which takes an argument of the type [A].
-  ///
+  @Deprecated(
+    'ResponsibilityNode and FunctionalNode handlers are replaced by '
+    'IResponsibilityNodeBase and IResponsibilityNode respectively and will be removed in 2.0.0',
+  )
   const FunctionalNode.withArgs(this.handler);
 
   @override

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -3,17 +3,19 @@ import 'dart:async';
 import 'result.dart';
 
 /// A function that takes an argument of the type [A] and returns FutureOr<[ChainResult]<[R]>>.
-///
+@Deprecated(
+  'FunctionHandlers are replaced by IResponsibilityNode type and will be removed in 2.0.0',
+)
 typedef FunctionHandler<R, A> = FutureOr<ChainResult<R>> Function(A args);
 
 /// A function that takes no arguments and returns FutureOr<[ChainResult]<[R]>>.
-///
+@Deprecated(
+  'FunctionHandlers are replaced by IResponsibilityNode type and will be removed in 2.0.0',
+)
 typedef VoidFunctionHandler<R> = FutureOr<ChainResult<R>> Function();
 
 /// A function that takes an argument of the type [A] and returns a value of type [R].
-///
 typedef ParametrizedSupplier<R, A> = R Function(A args);
 
 /// A function that takes no arguments and returns a value of type [R];
-///
 typedef Supplier<R> = R Function();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: responsibility_chain
 description: An asynchronous Responsibility Chain design pattern implementation with functional and object-oriented approaches to implementing handlers of responsibility.
-version: 1.0.3
+version: 1.1.0
 repository: https://github.com/mitryp/responsibility_chain
 issue_tracker: https://github.com/mitryp/responsibility_chain/issues
 
@@ -10,5 +10,6 @@ environment:
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.16.0
+
 dependencies:
   meta: ^1.15.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,3 +10,5 @@ environment:
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.16.0
+dependencies:
+  meta: ^1.15.0

--- a/test/responsibility_chain_test.dart
+++ b/test/responsibility_chain_test.dart
@@ -36,17 +36,20 @@ void testChainResult() {
 void testResponsibilityNodes() {
   group('ResponsibilityNode tests', () {
     test('ResponsibilityNodes with parameters succeed and fail correctly', () {
-      final conditionalFailNode =
-          ResponsibilityNodeMock<int>(conditionalFailChainResult);
+      final conditionalFailNode = ResponsibilityNodeMock<int>(
+        conditionalFailChainResult,
+      );
       repeatedIntTest(
-          (value) => testConditionalFailNode(conditionalFailNode, value));
+        (value) => testConditionalFailNode(conditionalFailNode, value),
+      );
     });
 
     test('FunctionalNodes with parameters succeed and fail correctly', () {
       final conditionalFailNode =
           FunctionalNode<int, int>.withArgs(conditionalFailChainResult);
       repeatedIntTest(
-          (value) => testConditionalFailNode(conditionalFailNode, value));
+        (value) => testConditionalFailNode(conditionalFailNode, value),
+      );
     });
   });
 }
@@ -55,23 +58,28 @@ void testResponsibilityChain() {
   group('ResponsibilityChain tests', () {
     const defaultValue = -1;
     late ResponsibilityChainWithArgs<int, int> chain;
-    late Iterable<ResponsibilityNodeMock<int>> nodes;
+    late Iterable<IResponsibilityNodeBase<int, int>> nodes;
 
     setUp(() {
       chain = ResponsibilityChainWithArgs(orElse: (_) => defaultValue);
       nodes = randomNodes();
-      chainNodesTo(chain, nodes: nodes);
+      for (final node in nodes) {
+        chain.chain(node);
+      }
     });
 
     test('ResponsibilityChain maintains the order of its nodes', () {
-      expect(chain.nodes.map((e) => e.call()), containsAllInOrder(nodes));
+      expect(chain.nodes, containsAllInOrder(nodes.map((e) => e.call)));
     });
 
     for (int i = 0; i < 100; i++) {
       test('ResponsibilityChain returns the correct result №${i + 1}', () {
         // each mock node returns its index in the list of nodes, while the default value is -1
-        final expectedResult =
-            nodes.map((e) => e.willSucceed).toList().indexWhere((e) => e!);
+        final expectedResult = nodes
+            .cast<IResponsibilityNodeMock<int>>()
+            .map((e) => e.willSucceed)
+            .toList()
+            .indexWhere((e) => e!);
 
         expect(chain.handle(defaultValue), completion(equals(expectedResult)));
       });

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -1,4 +1,5 @@
 import 'package:responsibility_chain/responsibility_chain.dart';
+import 'package:responsibility_chain/src/abs/node.dart';
 import 'package:responsibility_chain/src/chain.dart';
 import 'package:test/test.dart';
 
@@ -18,9 +19,6 @@ ChainResult<int> conditionalFailChainResult(int args) =>
 
 void chainNodesTo<R, A>(
   IResponsibilityChain<R, A> chain, {
-  required Iterable<ResponsibilityNode<R, A>> nodes,
-}) {
-  for (final node in nodes) {
-    chain.node(() => node);
-  }
-}
+  required Iterable<IResponsibilityNode<R, A>> nodes,
+}) =>
+    nodes.forEach(chain.chain);


### PR DESCRIPTION
- Unified the handler types with new `IResponsibilityNode` signature and `IResponsibilityNodeBase` hint interface.
- Added the `ResponsibilityChain.chain` method to replace the existing `node` and `funcNode` methods.
- Deprecated the `ResponsibilityNode`, `FunctionNode`, `FunctionHandler`, `ResponsibilityChain.node`, and `ResponsibilityChain.funcNode` entries. **These will be removed in 2.0.0.**